### PR TITLE
Teardown checks for app to stop()

### DIFF
--- a/features/support/selenium_world.js
+++ b/features/support/selenium_world.js
@@ -104,12 +104,16 @@ SeleniumWorld.prototype.cleanUp = function (callback) {
 
 SeleniumWorld.prototype.tearDown = function (callback) {
   var self = this;
-  self.app.stop();
-  self.browser.close(function () {
-    self.app = null;
-    self.browser = null;
+  if (self && self.app) {
+    self.app.stop();
+    self.browser.close(function () {
+      self.app = null;
+      self.browser = null;
+      callback();
+    });
+  } else {
     callback();
-  });
+  }
 };
 
 SeleniumWorld.prototype.prepareNewRecipeAttributes = function () {


### PR DESCRIPTION
I had to add an extra check in the teardown. If there is more than one step_definition as well as feature files it stops the app at the end of each step definition and the second time it tries to tear down it 'blows up'.
