### PR TITLE
Allow to install accessible versions to fix app installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,16 +11,16 @@
     "test": "cucumber.js"
   },
   "dependencies": {
-    "mongoose": "3.1.2",
-    "express":  "2.5.8",
-    "ejs":      "0.6.1",
-    "nopt":     "1.0.10"
+    "mongoose": "^3.1.2",
+    "express":  "^2.5.8",
+    "ejs":      "^0.6.1",
+    "nopt":     "^1.0.10"
   },
   "devDependencies": {
-    "cucumber":  "0.3.0",
-    "cukestall": "0.1.1",
-    "kite":      "0.0.1",
-    "async":     "0.1.22"
+    "cucumber":  "^0.3.0",
+    "cukestall": "^0.1.1",
+    "kite":      "^0.0.1",
+    "async":     "^0.1.22"
   },
   "optionalDependencies": {},
   "engines": {


### PR DESCRIPTION
``` bash
$ npm install --dev
npm ERR! Error: version not found: mongoose@3.1.2
npm ERR!     at /usr/local/lib/node_modules/npm/lib/cache/add-named.js:125:12
npm ERR!     at saved (/usr/local/lib/node_modules/npm/node_modules/npm-registry-client/lib/get.js:167:7)
npm ERR!     at Object.oncomplete (fs.js:107:15)
npm ERR! If you need help, you may report this *entire* log,
npm ERR! including the npm and node versions, at:
npm ERR!     <http://github.com/npm/npm/issues>

npm ERR! System Darwin 14.0.0
npm ERR! command "node" "/usr/local/bin/npm" "install" "--dev"
npm ERR! cwd /Users/marat/Dev/cukecipes
npm ERR! node -v v0.10.30
npm ERR! npm -v 1.4.23
npm ERR! 
npm ERR! Additional logging details can be found in:
npm ERR!     /Users/marat/Dev/cukecipes/npm-debug.log
npm ERR! not ok code 0
```
